### PR TITLE
Add configurable CommandTimeout value for SqlScriptRunnerTasklet

### DIFF
--- a/Summer.Batch.Extra/SqlScriptSupport/SqlScriptRunnerTasklet.cs
+++ b/Summer.Batch.Extra/SqlScriptSupport/SqlScriptRunnerTasklet.cs
@@ -40,6 +40,26 @@ namespace Summer.Batch.Extra.SqlScriptSupport
 
         private DbProviderFactory _providerFactory;
 
+        private int? _commandTimeout;
+
+        public int CommandTimeout
+        {
+            get
+            {
+                if (_commandTimeout == null)
+                {
+                    // Return default command timeout if not provided
+                    _commandTimeout = 30;
+                }
+
+                return _commandTimeout.Value;
+            }
+            set
+            {
+                _commandTimeout = value;
+            }
+        }
+
         /// <summary>
         /// The connection string to the database
         /// </summary>
@@ -98,6 +118,7 @@ namespace Summer.Batch.Extra.SqlScriptSupport
                 string preparedCommand = PrepareCommands(Resource);
                 DbCommand command = connection.CreateCommand();
                 command.CommandText = preparedCommand;
+                command.CommandTimeout = CommandTimeout;
                 int sqlDone = command.ExecuteNonQuery();
                 if(Logger.IsTraceEnabled)
                 {

--- a/Summer.Batch.Extra/SqlScriptSupport/SqlScriptRunnerTasklet.cs
+++ b/Summer.Batch.Extra/SqlScriptSupport/SqlScriptRunnerTasklet.cs
@@ -42,6 +42,11 @@ namespace Summer.Batch.Extra.SqlScriptSupport
 
         private int? _commandTimeout;
 
+        /// <summary>
+        /// Default timeout is 30 seconds based on MSDN
+        /// If a 0 timeout is provided, this means there is no timeout limit
+        /// Allows the user to specify a longer timeout to account for longer running scripts than 30 seconds
+        /// </summary>
         public int CommandTimeout
         {
             get


### PR DESCRIPTION
When running scripts using the SqlScriptRunnerTasklet, we encountered scripts that run longer than the default 30 seconds. Digging into the SummerBatch code, we saw that there was no way to provide a custom/configured command timeout value. 

This request updates the SqlScriptRunnerTasklet class to allow the user to provide a CommandTimeout value if they choose, and defaults to the C# standard 30 seconds if nothing is provided as part of the UnityLoader declaration for the step.